### PR TITLE
Add nginx template for beanstalkd

### DIFF
--- a/manifests/console.pp
+++ b/manifests/console.pp
@@ -53,6 +53,7 @@
 class beanstalkd::console (
   $install_dir     = $beanstalkd::params::install_dir,
   $apache_config   = false,
+  $nginx_config    = false,
   $webserver_port  = $beanstalkd::params::webserver_port,
   $vhostaddress    = $beanstalkd::params::vhostaddress,
   $web_username    = $beanstalkd::params::web_username,
@@ -110,6 +111,23 @@ class beanstalkd::console (
           ensure  => link,
           target  => '/etc/apache2/sites-available/beanstalk_console',
           require => File['/etc/apache2/sites-available/beanstalk_console'],
+          notify  => Service['apache2'];
+      }
+    }
+    if ($nginx_config == true) {
+      file {
+        '/etc/nginx/sites-available/beanstalk_console.conf':
+          ensure   => file,
+          content  => template('beanstalkd/etc/nginx/sites-available/beanstalk_console.conf.erb'),
+          mode     => '0644',
+          owner    => root,
+          group    => root,
+          notify   => Service['nginx'];
+
+        '/etc/nginx/sites-enabled/beanstalk_console.conf':
+          ensure  => link,
+          target  => '/etc/nginx/sites-available/beanstalk_console.conf',
+          require => File['/etc/nginx/sites-available/beanstalk_console.conf'],
           notify  => Service['apache2'];
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,4 +25,5 @@ class beanstalkd::params {
   $webserver_port = '80'
   $vhostaddress = "beanstalkconsole.${::fqdn}"
   $web_username = 'beanstalkd'
+  $php_owner = 'www-data'
 }

--- a/templates/etc/nginx/sites-available/beanstalk_console.conf.erb
+++ b/templates/etc/nginx/sites-available/beanstalk_console.conf.erb
@@ -3,7 +3,7 @@ server {
   server_name <%= @vhostaddress %>;
   server_name_in_redirect off;
 
-  root <%= @install_dir %>/public %>;
+  root <%= @install_dir %>/public;
 
   index index.html index.php;
 
@@ -15,8 +15,8 @@ server {
     include fastcgi_params;
     #allows to handle 404 in case of a file not found in fpm
     try_files $uri =404;
-    fastcgi_pass 127.0.0.1:<%= @fpm_port %>;
-    fastcgi_index index.php
+    fastcgi_pass 127.0.0.1:9000;
+    fastcgi_index index.php;
   }
 
 }

--- a/templates/etc/nginx/sites-available/beanstalk_console.conf.erb
+++ b/templates/etc/nginx/sites-available/beanstalk_console.conf.erb
@@ -1,0 +1,22 @@
+server {
+  listen <%= @webserver_port %>;
+  server_name <%= @vhostaddress %>;
+  server_name_in_redirect off;
+
+  root <%= @install_dir %>/public %>;
+
+  index index.html index.php;
+
+  location / {
+    try_files $uri $uri/ /index.php?$args;
+  }
+
+  location ~ ^(.+\.php)(.*)$ {
+    include fastcgi_params;
+    #allows to handle 404 in case of a file not found in fpm
+    try_files $uri =404;
+    fastcgi_pass 127.0.0.1:<%= @fpm_port %>;
+    fastcgi_index index.php
+  }
+
+}


### PR DESCRIPTION
This is a first version to add an template for beanstalkd console with nginx. I kept it simple and is advised to only run it behind fw/ssh tunnel.
